### PR TITLE
Fix rpc2 import paths.

### DIFF
--- a/lobby/lobby.go
+++ b/lobby/lobby.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/cenk/rpc2"
-	"github.com/cenk/rpc2/jsonrpc"
+	"github.com/cenkalti/rpc2"
+	"github.com/cenkalti/rpc2/jsonrpc"
 	geo "github.com/kellydunn/golang-geo"
 	"golang.org/x/net/websocket"
 )

--- a/lobby/lobby_test.go
+++ b/lobby/lobby_test.go
@@ -7,8 +7,8 @@ import (
 
 	"golang.org/x/net/websocket"
 
-	"github.com/cenk/rpc2"
-	"github.com/cenk/rpc2/jsonrpc"
+	"github.com/cenkalti/rpc2"
+	"github.com/cenkalti/rpc2/jsonrpc"
 	"github.com/d4l3k/messagediff"
 )
 


### PR DESCRIPTION
The rpc2 package moved from github.com/cenk/rpc2 to github.com/cenkalti/rpc2.